### PR TITLE
Fix sidekiq queues

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,12 +1,10 @@
 :concurrency: 5
 :queues:
-  - [mailers, 4]
-  - [default, 2]
-  - [newsletter, 2]
-  - [newsletters_opt_in, 2]
-  - [conference_diplomas, 2]
-  - [decidim_events, 2]
-  - [events, 2]
-  - [user_report, 2]
-  - [block_user, 2]
-  - [metrics, 1]
+- default
+- mailers
+- newsletter
+- decidim_events
+- events
+- metrics
+- exports
+- translations


### PR DESCRIPTION
exports queue not load automatically:

![imagen](https://user-images.githubusercontent.com/75725233/161717231-15943068-aa62-4ed3-9ec6-44706452bb14.png)

Queues have been changed for version 0.25.